### PR TITLE
Add Go webapp displaying greeting in large blue font

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module greeting-webapp
+
+go 1.22.2

--- a/main.go
+++ b/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+)
+
+const page = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Greeting</title>
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #f0f4f8;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    }
+    h1 {
+      color: #0052cc;
+      font-size: 3rem;
+      text-align: center;
+      padding: 0 1rem;
+    }
+  </style>
+</head>
+<body>
+  <h1>Hello Atlassian from Cursor Cloud Agents</h1>
+</body>
+</html>`
+
+func main() {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, page)
+	})
+
+	addr := ":8080"
+	log.Printf("Listening on %s", addr)
+	log.Fatal(http.ListenAndServe(addr, nil))
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a minimal Go HTTP server that displays **"Hello Atlassian from Cursor Cloud Agents"** in large blue font, centered on the page.

## Details

- **`main.go`** – Single-file Go web server using only the standard library (`net/http`). Listens on port `8080` and serves an HTML page with the greeting message.
- **Styling** – The message is rendered as an `<h1>` in Atlassian blue (`#0052cc`) at `3rem` font size, vertically and horizontally centered on a light background.
- **`go.mod`** – Module file for the project.

## How to run

```bash
go run main.go
# Then open http://localhost:8080
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ccd83102-8117-4310-a43f-9b23dcb57167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ccd83102-8117-4310-a43f-9b23dcb57167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

