### PR TITLE
Add Go webapp displaying greeting in large blue font

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+greeting-webapp

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module greeting-webapp
+
+go 1.22.2

--- a/main.go
+++ b/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+)
+
+const page = `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Greeting</title>
+    <style>
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: #f0f4f8;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        }
+        h1 {
+            font-size: 3.5rem;
+            color: #0052CC;
+            text-align: center;
+            padding: 0 1rem;
+        }
+    </style>
+</head>
+<body>
+    <h1>Hello Atlassian from Cursor Cloud Agents</h1>
+</body>
+</html>`
+
+func main() {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, page)
+	})
+
+	addr := ":8080"
+	log.Printf("Listening on %s", addr)
+	log.Fatal(http.ListenAndServe(addr, nil))
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

A simple Go webapp that displays **"Hello Atlassian from Cursor Cloud Agents"** in large blue font, centered on the page.

## Details

- **`main.go`** — Single-file Go HTTP server that listens on port 8080 and serves an HTML page with the greeting message.
- The text is rendered in Atlassian blue (`#0052CC`), at `3.5rem` font size, centered both vertically and horizontally.
- Clean, modern UI using system fonts and a light background.
- No external dependencies — uses only the Go standard library.

## How to run

```bash
go run main.go
# Then open http://localhost:8080
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e647a9d-5a73-47dc-8653-99481e0635d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e647a9d-5a73-47dc-8653-99481e0635d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

