### PR TITLE
Add Go webapp: "Hello Atlassian from Cursor Cloud Agents"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module hello-atlassian
+
+go 1.22.2

--- a/main.go
+++ b/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+)
+
+const page = `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hello Atlassian</title>
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: #f4f5f7;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+        }
+        h1 {
+            font-size: 3.5rem;
+            color: #0052CC;
+            text-align: center;
+            padding: 2rem;
+        }
+    </style>
+</head>
+<body>
+    <h1>Hello Atlassian from Cursor Cloud Agents</h1>
+</body>
+</html>`
+
+func main() {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, page)
+	})
+
+	log.Println("Server starting on :8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a simple Go web application that serves an HTML page displaying **"Hello Atlassian from Cursor Cloud Agents"** in large blue font.

## Details

- **`main.go`** — Starts an HTTP server on port `8080` that serves a single HTML page with the message styled in large (`3.5rem`) Atlassian-blue (`#0052CC`) font, centered on a light background.
- **`go.mod`** — Go module definition (no external dependencies).

## How to run

```bash
go run main.go
# then open http://localhost:8080
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db884609-b7cf-40c4-8c5b-17eb65c3eebe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db884609-b7cf-40c4-8c5b-17eb65c3eebe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

