### PR TITLE
Add Go webapp displaying "Hello Atlassian from Cursor Cloud Agents"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+hello-atlassian-webapp

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# hello-agent
+# Hello Atlassian Webapp
+
+A simple Go web application that displays "Hello Atlassian from Cursor Cloud Agents" in large blue font.
+
+## Running
+
+```bash
+go run main.go
+```
+
+Then open [http://localhost:8080](http://localhost:8080) in your browser.
+
+## Building
+
+```bash
+go build -o hello-atlassian-webapp .
+./hello-atlassian-webapp
+```

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module hello-atlassian-webapp
+
+go 1.22.2

--- a/main.go
+++ b/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+)
+
+const page = `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hello Atlassian</title>
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: #f4f5f7;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+        }
+        h1 {
+            font-size: 3.5rem;
+            color: #0052CC;
+            text-align: center;
+            padding: 2rem;
+        }
+    </style>
+</head>
+<body>
+    <h1>Hello Atlassian from Cursor Cloud Agents</h1>
+</body>
+</html>`
+
+func main() {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, page)
+	})
+
+	addr := ":8080"
+	log.Printf("Listening on %s", addr)
+	log.Fatal(http.ListenAndServe(addr, nil))
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a simple Go web application that serves an HTML page displaying the message **"Hello Atlassian from Cursor Cloud Agents"** in large blue font.

## Changes

- **`main.go`** — HTTP server listening on `:8080`, serves a single HTML page with the message styled in large (`3.5rem`) Atlassian blue (`#0052CC`) font, centered on the page.
- **`go.mod`** — Go module definition (`hello-atlassian-webapp`).
- **`.gitignore`** — Excludes the compiled binary.
- **`README.md`** — Updated with build and run instructions.

## How to run

```bash
go run main.go
# then visit http://localhost:8080
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0cdbab10-75be-4edc-9a1a-b47a73f193f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0cdbab10-75be-4edc-9a1a-b47a73f193f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

