### PR TITLE
Add Go webapp displaying greeting in large blue font

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+greeting-webapp

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# hello-agent
+# Greeting Webapp
+
+A simple Go web application that displays "Hello Atlassian from Cursor Cloud Agents" in large blue font.
+
+## Running
+
+```bash
+go run main.go
+```
+
+The server starts on port **8080**. Open <http://localhost:8080> in your browser.
+
+## Building
+
+```bash
+go build -o greeting-webapp .
+./greeting-webapp
+```

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module greeting-webapp
+
+go 1.22.2

--- a/main.go
+++ b/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+)
+
+const page = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Greeting</title>
+  <style>
+    body {
+      margin: 0;
+      height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #f0f4f8;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    }
+    h1 {
+      font-size: 3rem;
+      color: #0052cc;
+    }
+  </style>
+</head>
+<body>
+  <h1>Hello Atlassian from Cursor Cloud Agents</h1>
+</body>
+</html>`
+
+func main() {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, page)
+	})
+
+	addr := ":8080"
+	log.Printf("Listening on %s", addr)
+	log.Fatal(http.ListenAndServe(addr, nil))
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a simple Go web application that displays **"Hello Atlassian from Cursor Cloud Agents"** in large blue font.

## Details

- **`main.go`** — Serves an HTML page on port 8080 with the greeting styled in large (`3rem`) blue (`#0052cc`) font, centered on the page.
- **`go.mod`** — Go module definition (no external dependencies).
- **`README.md`** — Instructions for running and building the app.

## How to run

```bash
go run main.go
# then open http://localhost:8080
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a09e4bca-4c66-476c-b273-3e4fe0424dc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a09e4bca-4c66-476c-b273-3e4fe0424dc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

