### PR TITLE
Add Hello World web application in Go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module hello-agent
+
+go 1.21

--- a/main.go
+++ b/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	html := `<!DOCTYPE html>
+<html>
+<head>
+    <title>Hello Atlassian</title>
+</head>
+<body>
+    <h1 style="color: blue; font-size: 48px;">Hello Atlassian from Claude Managed Agents</h1>
+</body>
+</html>`
+	fmt.Fprint(w, html)
+}
+
+func main() {
+	http.HandleFunc("/", handler)
+	fmt.Println("Server starting on http://localhost:8080")
+	http.ListenAndServe(":8080", nil)
+}


### PR DESCRIPTION
## Summary
This PR adds a simple Hello World web application written in Go.

## Changes
- **main.go**: HTTP server that listens on port 8080 and displays the message "Hello Atlassian from Claude Managed Agents" in large blue font
- **go.mod**: Go module definition

## How to run
```bash
go build -o hello-agent
./hello-agent
```
Then visit http://localhost:8080 in your browser.