### PR TITLE
Add Hello World web application in Go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module hello-agent
+
+go 1.24.7

--- a/main.go
+++ b/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func main() {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, `<!DOCTYPE html>
+<html>
+<head>
+    <title>Hello World</title>
+</head>
+<body>
+    <h1 style="color: blue; font-size: 48px;">Hello Atlassian from Claude Managed Agents</h1>
+</body>
+</html>`)
+	})
+
+	fmt.Println("Server starting on http://localhost:8080")
+	http.ListenAndServe(":8080", nil)
+}


### PR DESCRIPTION
## Summary

This PR adds a simple Hello World web application written in Go.

## Changes

- **main.go**: HTTP server that serves a web page on port 8080
- **go.mod**: Go module definition

## Features

- Displays "Hello Atlassian from Claude Managed Agents" in large blue font (48px)
- Lightweight HTTP server using Go's standard library
- No external dependencies

## How to Run

```bash
go run main.go
```

Then visit http://localhost:8080 in your browser.