### PR TITLE
Add Hello Atlassian Go web application

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/gclitheroe/hello-agent
+
+go 1.22

--- a/main.go
+++ b/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+)
+
+const message = "Hello Atlassian from the Claude Agent SDK"
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintln(w, message)
+}
+
+func main() {
+	http.HandleFunc("/", handler)
+	log.Println("Starting server on :8080")
+	if err := http.ListenAndServe(":8080", nil); err != nil {
+		log.Fatalf("Server failed: %v", err)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHandler(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+
+	handler(w, req)
+
+	res := w.Result()
+	if res.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", res.StatusCode)
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, message) {
+		t.Errorf("expected body to contain %q, got %q", message, body)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a minimal Go HTTP web server that responds with **"Hello Atlassian from the Claude Agent SDK"** on every request to `/`.
- Includes a `go.mod` so the module is self-contained and `go run .` / `go build` work out of the box.
- Adds a unit test (`main_test.go`) using `net/http/httptest` to verify the response status and body.

## How to run

```bash
go run .
# Server starts on :8080

curl http://localhost:8080
# Hello Atlassian from the Claude Agent SDK
```

## How to test

```bash
go test ./...
```

## Test plan

- [ ] `go build ./...` succeeds with no errors
- [ ] `go test ./...` passes
- [ ] `curl http://localhost:8080` returns `Hello Atlassian from the Claude Agent SDK`

🤖 Generated with [Claude Code](https://claude.com/claude-code)