### PR TITLE
Add Hello Atlassian Go web application

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/gclitheroe/hello-agent
+
+go 1.22

--- a/main.go
+++ b/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+)
+
+const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hello Atlassian</title>
+    <style>
+        body {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+            margin: 0;
+            background-color: #f4f5f7;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        }
+        h1 {
+            color: #0052cc;
+            font-size: 4rem;
+            text-align: center;
+            padding: 2rem;
+        }
+    </style>
+</head>
+<body>
+    <h1>Hello Atlassian from the Claude Agent SDK</h1>
+</body>
+</html>`
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprint(w, html)
+}
+
+func main() {
+	http.HandleFunc("/", handler)
+	log.Println("Server listening on http://localhost:8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}


### PR DESCRIPTION
## Summary

- Adds a minimal Go HTTP web server (`main.go`) that serves a single HTML page
- Displays **"Hello Atlassian from the Claude Agent SDK"** in large blue font (Atlassian blue `#0052cc`, `4rem`)
- Adds `go.mod` to initialise the Go module (no external dependencies)

## Running locally

```bash
go run main.go
# then open http://localhost:8080
```

## Test plan

- [ ] `go build ./...` compiles without errors
- [ ] `go run main.go` starts the server on port 8080
- [ ] Visiting `http://localhost:8080` displays the message in large blue text
- [ ] Page renders correctly on mobile viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)