### PR TITLE
Add Hello Atlassian Go web application

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/gclitheroe/hello-agent
+
+go 1.22

--- a/main.go
+++ b/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+)
+
+const page = `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hello Atlassian</title>
+    <style>
+        body {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+            margin: 0;
+            background-color: #f5f5f5;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        }
+        h1 {
+            font-size: 4rem;
+            color: #0052CC;
+            text-align: center;
+            padding: 2rem;
+        }
+    </style>
+</head>
+<body>
+    <h1>Hello Atlassian from the Claude Agent SDK</h1>
+</body>
+</html>`
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprint(w, page)
+}
+
+func main() {
+	http.HandleFunc("/", handler)
+	log.Println("Starting server on :8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}


### PR DESCRIPTION
## Summary

- Adds a minimal Go web application that serves a single HTML page
- Displays **"Hello Atlassian from the Claude Agent SDK"** in large blue font (`#0052CC` — Atlassian blue)
- Uses only the Go standard library (`net/http`) — no external dependencies

## Files

| File | Purpose |
|------|---------|
| `main.go` | HTTP server — serves the HTML page on `:8080` |
| `go.mod` | Go module definition |

## Running the app

```bash
go run main.go
```

Then open http://localhost:8080 in your browser.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) using the Claude Agent SDK