### PR TITLE
Add Go stdlib hello world web application

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+)
+
+func helloHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	fmt.Fprintln(w, "hello world from Codex")
+}
+
+func main() {
+	http.HandleFunc("/", helloHandler)
+	log.Println("server listening on http://localhost:8080")
+	if err := http.ListenAndServe(":8080", nil); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
### Motivation

- Provide a minimal Go web application example using only the standard library that responds with a plain-text greeting.

### Description

- Add `main.go` which registers a root handler (`/`) that returns `hello world from Codex` with `Content-Type: text/plain; charset=utf-8` and starts an HTTP server on `:8080` using only `net/http`, `log`, and `fmt`.

### Testing

- Ran `gofmt -w main.go` and started the server with `go run main.go` to verify startup and response; both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00498c6adc8325ac924e9725b94a7f)