### PR TITLE
Add Go hello world web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # hello-agent
+
+A minimal Hello World web application written in Go using only the standard
+library.
+
+## Run
+
+```sh
+go run .
+```
+
+Then open http://localhost:8080.
+
+Set `PORT` to choose a different port:
+
+```sh
+PORT=3000 go run .
+```
+
+## Test
+
+```sh
+go test ./...
+```

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module hello-agent
+
+go 1.25

--- a/main.go
+++ b/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+)
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", helloHandler)
+
+	addr := ":8080"
+	if port := os.Getenv("PORT"); port != "" {
+		addr = ":" + port
+	}
+
+	log.Printf("listening on http://localhost%s", addr)
+	if err := http.ListenAndServe(addr, mux); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func helloHandler(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	fmt.Fprintln(w, "Hello, world!")
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHelloHandler(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+
+	helloHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+
+	if got, want := rec.Body.String(), "Hello, world!\n"; got != want {
+		t.Fatalf("expected body %q, got %q", want, got)
+	}
+
+	if got, want := rec.Header().Get("Content-Type"), "text/plain; charset=utf-8"; got != want {
+		t.Fatalf("expected content type %q, got %q", want, got)
+	}
+}
+
+func TestHelloHandlerNotFound(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/missing", nil)
+	rec := httptest.NewRecorder()
+
+	helloHandler(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected status %d, got %d", http.StatusNotFound, rec.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- Add a minimal Go stdlib web server serving `Hello, world!` at `/`
- Add handler tests using `net/http/httptest`
- Document run and test commands in `README.md`

## Tests
- `GOCACHE=$(pwd)/.gocache go test ./...`

## Note
- The checkout’s `.git` directory rejected lock-file writes in this sandbox, so the successful commit was created via a writable copied git dir: `3ddcda7 Add Go hello world web app`.