### PR TITLE
Add Go hello world web app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.gocache/
+.git-writable/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # hello-agent
+
+A small Go web application that serves:
+
+> Hello Atlassian from the Codex SDK
+
+The app uses only the Go standard library.
+
+## Run
+
+```sh
+go run .
+```
+
+Open http://localhost:8080.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module hello-agent
+
+go 1.25.1

--- a/main.go
+++ b/main.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"fmt"
+	"html/template"
+	"log"
+	"net/http"
+	"os"
+)
+
+const message = "Hello Atlassian from the Codex SDK"
+
+var page = template.Must(template.New("home").Parse(`<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Hello Atlassian</title>
+  <style>
+    body {
+      min-height: 100vh;
+      margin: 0;
+      display: grid;
+      place-items: center;
+      font-family: Arial, Helvetica, sans-serif;
+      background: #ffffff;
+    }
+
+    h1 {
+      margin: 0;
+      color: #0052cc;
+      font-size: 4rem;
+      line-height: 1.1;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <h1>{{.Message}}</h1>
+</body>
+</html>
+`))
+
+type pageData struct {
+	Message string
+}
+
+func homeHandler(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := page.Execute(w, pageData{Message: message}); err != nil {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+	}
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", homeHandler)
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	addr := ":" + port
+	fmt.Printf("Listening on http://localhost%s\n", addr)
+	log.Fatal(http.ListenAndServe(addr, mux))
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHomeHandlerRendersMessageWithLargeBlueFont(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+
+	homeHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+
+	body := rec.Body.String()
+	checks := []string{
+		"Hello Atlassian from the Codex SDK",
+		"color: #0052cc",
+		"font-size: 4rem",
+	}
+	for _, want := range checks {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected response body to contain %q", want)
+		}
+	}
+
+	contentType := rec.Header().Get("Content-Type")
+	if !strings.HasPrefix(contentType, "text/html; charset=utf-8") {
+		t.Fatalf("expected HTML content type, got %q", contentType)
+	}
+}
+
+func TestHomeHandlerReturnsNotFoundForOtherPaths(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/missing", nil)
+	rec := httptest.NewRecorder()
+
+	homeHandler(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected status %d, got %d", http.StatusNotFound, rec.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- Add a minimal Go `net/http` web app using only the standard library
- Render `Hello Atlassian from the Codex SDK` in a large blue heading
- Add focused handler tests and README run instructions

## Tests
- `GOCACHE=$(pwd)/.gocache go test ./...`