### PR TITLE
Add Go hello world web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # hello-agent
+
+A stdlib-only Go web application that renders:
+
+> Hello Atlassian from the Codex SDK
+
+## Run
+
+```sh
+go run .
+```
+
+The server listens on `http://localhost:8080` by default. Set `PORT` to use a different port.
+
+## Test
+
+```sh
+go test ./...
+```

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module hello-agent
+
+go 1.25

--- a/main.go
+++ b/main.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+)
+
+const message = "Hello Atlassian from the Codex SDK"
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", helloHandler)
+
+	addr := ":" + port()
+	log.Printf("listening on http://localhost%s", addr)
+	if err := http.ListenAndServe(addr, mux); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func port() string {
+	if value := os.Getenv("PORT"); value != "" {
+		return value
+	}
+	return "8080"
+}
+
+func helloHandler(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprintf(w, `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>%[1]s</title>
+  <style>
+    html, body {
+      height: 100%%;
+    }
+
+    body {
+      margin: 0;
+      display: grid;
+      place-items: center;
+      font-family: Arial, Helvetica, sans-serif;
+      background: #ffffff;
+    }
+
+    h1 {
+      margin: 0;
+      color: #0052cc;
+      font-size: clamp(3rem, 10vw, 8rem);
+      font-weight: 800;
+      text-align: center;
+      line-height: 1.05;
+    }
+  </style>
+</head>
+<body>
+  <h1>%[1]s</h1>
+</body>
+</html>
+`, message)
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHelloHandlerRendersMessageAndBlueFont(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+
+	helloHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+
+	body := rec.Body.String()
+	for _, want := range []string{
+		"Hello Atlassian from the Codex SDK",
+		"color: #0052cc",
+		"font-size: clamp(3rem, 10vw, 8rem)",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected response body to contain %q", want)
+		}
+	}
+}
+
+func TestHelloHandlerNotFound(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/missing", nil)
+	rec := httptest.NewRecorder()
+
+	helloHandler(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected status %d, got %d", http.StatusNotFound, rec.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- Add a stdlib-only Go HTTP server rendering “Hello Atlassian from the Codex SDK”
- Style the message with a large blue font
- Add focused handler tests and README usage instructions

## Tests
- `GOCACHE=/tmp/codex-go-build-cache go test ./...`

## Note
- The sandbox blocked writes inside the checkout’s `.git` directory, so the required `git add` and `git commit` were completed against a writable Git metadata copy at `/tmp/codex-git-copy` on branch `codex/a2a-50771b07`.