### PR TITLE
Add Python calculator that adds positive integers

### DIFF
--- a/calculator.py
+++ b/calculator.py
@@ -1,0 +1,14 @@
+"""A simple calculator."""
+
+
+def add(a, b):
+    """Add together two positive integers.
+
+    Raises ValueError if either argument is not a positive integer.
+    """
+    for value in (a, b):
+        if not isinstance(value, int) or isinstance(value, bool):
+            raise ValueError("arguments must be integers")
+        if value <= 0:
+            raise ValueError("arguments must be positive integers")
+    return a + b

--- a/test_calculator.py
+++ b/test_calculator.py
@@ -1,0 +1,28 @@
+"""Tests for the calculator."""
+
+import unittest
+
+from calculator import add
+
+
+class TestAdd(unittest.TestCase):
+    def test_add_small_positive_integers(self):
+        self.assertEqual(add(1, 2), 3)
+
+    def test_add_larger_positive_integers(self):
+        self.assertEqual(add(100, 250), 350)
+
+    def test_add_is_commutative(self):
+        self.assertEqual(add(7, 13), add(13, 7))
+
+    def test_add_rejects_non_positive_integers(self):
+        with self.assertRaises(ValueError):
+            add(0, 5)
+
+    def test_add_rejects_non_integers(self):
+        with self.assertRaises(ValueError):
+            add(1.5, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a small `add()` calculator that sums two positive integers and rejects non-positive or non-integer input.

`test_calculator.py` covers 5 cases (small/large sums, commutativity, non-positive rejection, non-integer rejection). Tests use the stdlib `unittest` runner since `pytest`/`pip` aren't available in this environment.

```
python3 -m unittest -v
```
All 5 tests pass.